### PR TITLE
Fix Python 3 syntax errors

### DIFF
--- a/pytest_dbfixtures/factories/rabbitmq.py
+++ b/pytest_dbfixtures/factories/rabbitmq.py
@@ -275,7 +275,7 @@ def rabbitmq(
         try:
             rabbit_connection = pika.BlockingConnection(rabbit_params)
         except pika.adapters.blocking_connection.exceptions.ConnectionClosed:
-            print "Be sure that you're connecting rabbitmq-server >= 2.8.4"
+            print("Be sure that you're connecting rabbitmq-server >= 2.8.4")
 
         def finalizer():
             teardown(process, rabbit_connection)

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -13,11 +13,11 @@ rabbitmq2 = factories.rabbitmq('rabbitmq_proc2', port=5674)
 
 def test_second_rabbitmq(rabbitmq, rabbitmq2):
 
-    print 'checking first channel'
+    print('checking first channel')
     channel = rabbitmq.channel()
     assert channel.is_open
 
-    print 'checking second channel'
+    print('checking second channel')
     channel2 = rabbitmq2.channel()
     assert channel2.is_open
 


### PR DESCRIPTION
Fixes this exception when running `pip install pytest-dbfixtures` under
Python 3.4.1:

```
Installing collected packages: pytest-dbfixtures
  Running setup.py install for pytest-dbfixtures

      File "/home/dwon/.pyenv/versions/inbox34/lib/python3.4/site-packages/pytest_dbfixtures/factories/rabbitmq.py", line 278
        print "Be sure that you're connecting rabbitmq-server >= 2.8.4"
                                                                      ^
    SyntaxError: invalid syntax

Successfully installed pytest-dbfixtures
```
