### PR TITLE
#78 xdist not-working fix: path() objects wasn't serializable so now the...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,12 @@ language: python
 python:
 - '2.7'
 install:
-- python setup.py develop
-- pip install pymongo redis pika MySQL-python psycopg2 elasticsearch pylama
-- "pip install pytest_dbfixtures[tests] coveralls"
+- "python setup.py develop"
+- "pip install pytest_dbfixtures[mongodb,redis,rabbitmq,mysql,postgresql,elasticsearch,tests]"
 # manually install wheel for deployment
 - "pip install wheel"
 script:
-- py.test --cov pytest_dbfixtures -lv tests
+- py.test -n 1 --showlocals --verbose --cov pytest_dbfixtures tests
 - pylama
 after_success:
     - coveralls

--- a/pytest_dbfixtures/plugin.py
+++ b/pytest_dbfixtures/plugin.py
@@ -23,13 +23,14 @@ from pytest_dbfixtures import factories
 
 
 ROOT_DIR = path(__file__).parent.parent.abspath()
+CONF_DIR = ROOT_DIR / 'pytest_dbfixtures' / 'conf'
 
 
 def pytest_addoption(parser):
     parser.addoption(
         '--dbfixtures-config',
         action='store',
-        default=ROOT_DIR / 'pytest_dbfixtures' / 'conf' / 'dbfixtures.conf',
+        default=str(CONF_DIR / 'dbfixtures.conf'),
         metavar='path',
         dest='db_conf',
     )
@@ -37,7 +38,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--redis-config',
         action='store',
-        default=ROOT_DIR / 'pytest_dbfixtures' / 'conf' / 'redis.conf',
+        default=str(CONF_DIR / 'redis.conf'),
         metavar='path',
         dest='redis_conf',
     )
@@ -45,7 +46,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--rabbit-config',
         action='store',
-        default=ROOT_DIR / 'pytest_dbfixtures' / 'conf' / 'rabbit.conf',
+        default=str(CONF_DIR / 'rabbit.conf'),
         metavar='path',
         dest='rabbit_conf',
     )

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,18 @@ setup(
     include_package_data=True,
     extras_require={
         'documentation': ["Sphinx", ],
-        'tests': ['pytest-cov']
+        'tests': [
+            'pytest-cov',
+            'pytest-xdist',
+            'coveralls',
+            'pylama',
+        ],
+        'mysql': ['MySQL-python'],
+        'postgresql': ['psycopg2'],
+        'mongodb': ['pymongo'],
+        'elasticsearch': ['elasticsearch'],
+        'redis': ['redis'],
+        'rabbitmq': ['pika'],
     },
     entry_points={
         'pytest11': [


### PR DESCRIPTION
path() objects wasn't serializable so now they are casted into the plain string
