### PR TITLE
added StrictRedis support

### DIFF
--- a/pytest_dbfixtures/factories/redis.py
+++ b/pytest_dbfixtures/factories/redis.py
@@ -96,6 +96,7 @@ def redisdb(process_fixture_name, host=None, port=None, db=None, strict=True):
     :param str host: hostname
     :param int port: port
     :param int db: number of database
+    :param bool strict: if true, uses StrictRedis client class
     :rtype: func
     :returns: function which makes a connection to redis
     """


### PR DESCRIPTION
redis-py client has two implementations: Redis and StrictRedis, which differ slightly in their semantics (code written for StrictRedis might not pass the tests using Redis, for example, if ZADD method is used).
A 'strict' boolean flag is added to redisdb fixture to support both implementations.
Since StrictRedis is the recommended implementation, it is set by default.
