### PR TITLE
Old versions of Redis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,18 @@ python:
 - '2.7'
 - '3.3'
 - '3.4'
+before_install:
+  - wget -O redis-2.4.14.tar.gz https://redis.googlecode.com/files/redis-2.4.14.tar.gz
+  - tar xzf redis-2.4.14.tar.gz
+  - cd redis-2.4.14
+  - make
+  - make test
+  - sudo make install
+  - cd utils
+  - yes | sudo ./install_server.sh
+  - cd ../../
+  - /usr/local/bin/redis-server --version
+  - /usr/bin/redis-server --version
 install:
 - "python setup.py develop"
 - "pip install -e .[mongodb,redis,rabbitmq,mysql,postgresql,elasticsearch,tests]"

--- a/pytest_dbfixtures/utils.py
+++ b/pytest_dbfixtures/utils.py
@@ -17,6 +17,7 @@
 # along with pytest-dbfixtures.  If not, see <http://www.gnu.org/licenses/>.
 
 import importlib
+import re
 
 from pymlconf import ConfigManager
 
@@ -73,3 +74,38 @@ def get_process_fixture(request, process_name):
     if not process.running():
         process.start()
     return process
+
+
+def compare_version(version1, version2):
+    """
+    This function compares two version numbers.
+
+    :param str version1: first version to compare
+    :param str version2: second version to compare
+    :rtype: int
+    :returns: return value is negative if version1 < version2,
+        zero if version1 == version2
+        and strictly positive if version1 > version2
+    """
+    def normalize(v):
+        return [int(x) for x in re.sub(r'(\.0+)*$', '', v).split(".")]
+
+    def cmp_v(v1, v2):
+        return (v1 > v2) - (v1 < v2)
+    return cmp_v(normalize(version1), normalize(version2))
+
+
+def extract_version(text):
+    """
+    This function extracts version number from text.
+
+    :param str text: text that contains the version number
+    :rtype: str
+    :returns: version number, e.g., "2.4.14"
+    """
+    match_object = re.search('\d+(?:\.\d+)+', text)
+    if match_object:
+        extracted_version = match_object.group(0)
+    else:
+        extracted_version = None
+    return extracted_version

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,4 +1,8 @@
+import pytest
+
 from pytest_dbfixtures import factories
+from pytest_dbfixtures.factories.redis import RedisUnsupported
+from pytest_dbfixtures.utils import extract_version, compare_version
 
 
 def test_redis(redisdb):
@@ -40,3 +44,40 @@ redisdb_random = factories.redisdb('redis_proc_random')
 def test_random_port(redisdb_random):
     """Tests if redis fixture can be started on random port"""
     assert redisdb_random.keys('*') == []
+
+
+redis_proc_old_redis = factories.redis_proc(
+    executable='/usr/local/bin/redis-server',
+    port='?')
+redisdb_old_redis = factories.redisdb('redis_proc_old_redis')
+
+
+@pytest.mark.xfail(raises=RedisUnsupported)
+def test_old_redis(redisdb_old_redis):
+    """Tests how fixture behaves in case of old redis version"""
+    pass
+
+
+@pytest.mark.parametrize("versions,result", [
+    (["2.8.18", "2.6"], 1),
+    (["2.4.14", "2.6"], -1),
+    (["2.6.0", "2.6"], 0),
+    (["3.0.0", "2.6.17"], 1),
+    (["2.6.1", "2.6.17"], -1),
+])
+def test_compare_version(versions, result):
+    assert compare_version(versions[0], versions[1]) == result
+
+
+@pytest.mark.parametrize("text,result", [
+    ("Redis server version 2.4.14 (00000000:0)", "2.4.14"),
+    ("Redis server v=2.6.13 sha=00000000:0 malloc=jemalloc-3.3.1 bits=64",
+     "2.6.13"),
+    ("1.2.5", "1.2.5"),
+    ("Test2.0.5", "2.0.5"),
+    ("2.0.5Test", "2.0.5"),
+    ("Test", None),
+    ("m.n.a 2.4.14", "2.4.14")
+])
+def test_extract_version(text, result):
+    assert extract_version(text) == result


### PR DESCRIPTION
This fixes the problem described here -> https://github.com/ClearcodeHQ/pytest-dbfixtures/issues/93
In case of using unsupported version of Redis an adequate message will be displayed.

I tested this with Redis 2.4.14 and Redis 2.8.18:
- redis 2.4.14: https://travis-ci.org/marspe/pytest-dbfixtures/builds/43737867
- redis 2.8.18: https://travis-ci.org/marspe/pytest-dbfixtures/builds/43742926

dbfixtures.conf:
- redis 2.4.14: redis_exec: /usr/local/bin/redis-server
- redis 2.8.18: redis_exec: /usr/bin/redis-server
