### PR TITLE
Use port number in default RabbitMQ node name.

### DIFF
--- a/pytest_dbfixtures/factories/rabbitmq.py
+++ b/pytest_dbfixtures/factories/rabbitmq.py
@@ -142,7 +142,9 @@ def rabbitmq_proc(config_file=None, server=None, host=None, port=None,
                 '2000-3000' - random available port from a given range
                 '4002,4003' - random of 4002 or 4003 ports
         :param str node_name: RabbitMQ node name used for setting environment
-                              variable RABBITMQ_NODENAME
+                              variable RABBITMQ_NODENAME (the default depends
+                              on the port number, so multiple nodes are not
+                              clustered)
         :param str rabbit_ctl_file: path to rabbitmqctl file
 
         :returns pytest fixture with RabbitMQ process executor
@@ -186,13 +188,15 @@ def rabbitmq_proc(config_file=None, server=None, host=None, port=None,
         rabbit_mnesia = rabbit_path + 'mnesia'
         rabbit_plugins = rabbit_path + 'plugins'
 
+        # Use the port number in node name, so multiple instances started
+        # at different ports will work separately instead of clustering.
+        chosen_node_name = node_name or 'rabbitmq-test-{0}'.format(rabbit_port)
+
         environ['RABBITMQ_LOG_BASE'] = rabbit_log
         environ['RABBITMQ_MNESIA_BASE'] = rabbit_mnesia
         environ['RABBITMQ_ENABLED_PLUGINS_FILE'] = rabbit_plugins
         environ['RABBITMQ_NODE_PORT'] = str(rabbit_port)
-
-        if node_name:
-            environ['RABBITMQ_NODENAME'] = node_name
+        environ['RABBITMQ_NODENAME'] = chosen_node_name
 
         rabbit_executor = RabbitMqExecutor(
             rabbit_server,

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -82,3 +82,16 @@ def test_random_port(rabbitmq_rand):
     """Tests if rabbit fixture can be started on random port"""
     channel = rabbitmq_rand.channel()
     assert channel.state == channel.OPEN
+
+
+rabbitmq_rand_proc2 = factories.rabbitmq_proc(port='?')
+rabbitmq_rand_proc3 = factories.rabbitmq_proc(port='?')
+
+
+def test_random_port_node_names(rabbitmq_rand_proc2, rabbitmq_rand_proc3):
+    """
+    Test that rabbitmq_proc fixtures with random ports get different node
+    names.
+    """
+    assert (rabbitmq_rand_proc2.env['RABBITMQ_NODENAME']
+            != rabbitmq_rand_proc3.env['RABBITMQ_NODENAME'])


### PR DESCRIPTION
This allows using just the port='?' argument to rabbitmq_proc to run multiple
independent RabbitMQ instances for use with xdist to parallelize tests on a
single machine.