### PR TITLE
Log destination and pg_hba.conf addition

### DIFF
--- a/pytest_dbfixtures/executors/postgresql.py
+++ b/pytest_dbfixtures/executors/postgresql.py
@@ -33,7 +33,8 @@ class PostgreSQLExecutor(TCPExecutor):
     """
 
     BASE_PROC_START_COMMAND = """{pg_ctl} start -D {datadir}
-    -o "-F -p {port} -c %s='{unixsocketdir}'" -l {logfile} {startparams}"""
+    -o "-F -p {port} -c log_destination='stderr' -c %s='{unixsocketdir}'"
+    -l {logfile} {startparams}"""
 
     PROC_START_COMMAND = {
         '8.4': BASE_PROC_START_COMMAND % 'unix_socket_directory',

--- a/pytest_dbfixtures/factories/postgresql.py
+++ b/pytest_dbfixtures/factories/postgresql.py
@@ -176,6 +176,11 @@ def postgresql_proc(executable=None, host=None, port=None, logs_prefix=''):
         init_postgresql_directory(
             postgresql_ctl, config.postgresql.user, datadir
         )
+
+
+        with open(os.path.join(datadir, 'pg_hba.conf'), 'a') as f:
+            f.write('host all all 0.0.0.0/0 trust')
+
         postgresql_executor = PostgreSQLExecutor(
             pg_ctl=postgresql_ctl,
             host=pg_host,


### PR DESCRIPTION
This commit fixes problems on FreeBSD environments.

```
-c log_destination='stderr'
```
Is very importent otherwise syslog will be used and the db-fixtures will hang as it looks in the expected log file and loops forever waiting for a "database is ready" entry to appear... `log_destination='stderr'` is default on most systems and can be set in `postgresql.conf` or given as an command line argument. 

The other addition is in regard to FreeBSD Jails, In jailed environments the loopback interface can not be used, thus it seems like the connection is comming from the ip address assigned to the jail.

