### PR TITLE
Use log destination param for pgsql

### DIFF
--- a/pytest_dbfixtures/executors/postgresql.py
+++ b/pytest_dbfixtures/executors/postgresql.py
@@ -35,7 +35,8 @@ class PostgreSQLExecutor(TCPExecutor):
     """
 
     BASE_PROC_START_COMMAND = """{pg_ctl} start -D {datadir}
-    -o "-F -p {port} -c %s='{unixsocketdir}'" -l {logfile} {startparams}"""
+    -o "-F -p {port} -c log_destination='stderr' -c %s='{unixsocketdir}'"
+    -l {logfile} {startparams}"""
 
     PROC_START_COMMAND = {
         '8.4': BASE_PROC_START_COMMAND % 'unix_socket_directory',


### PR DESCRIPTION
This commit ensures that `stderr` is used for logging, by
specifying the command line parameter.

On FreeBSD this is very important otherwise syslog will be used and
the db-fixtures will hang as it looks in the expected log file and
loops forever waiting for a "database is ready" entry to appear...
`log_destination=stderr` is default on most systems and can be set in
`postgresql.conf` or given as an command line argument.

Read more at
http://www.postgresql.org/docs/9.4/static/runtime-config-logging.html

This PR originates from #105 