### PR TITLE
pgSQL connection error on FreeBSD jailed environments

### DIFF
--- a/pytest_dbfixtures/factories/postgresql.py
+++ b/pytest_dbfixtures/factories/postgresql.py
@@ -17,6 +17,7 @@
 # along with pytest-dbfixtures.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import platform
 import shutil
 import subprocess
 import time
@@ -176,6 +177,11 @@ def postgresql_proc(executable=None, host=None, port=None, logs_prefix=''):
         init_postgresql_directory(
             postgresql_ctl, config.postgresql.user, datadir
         )
+
+        if 'FreeBSD' == platform.system():
+            with open(os.path.join(datadir, 'pg_hba.conf'), 'a') as f:
+                f.write('host all all 0.0.0.0/0 trust\n')
+
         postgresql_executor = PostgreSQLExecutor(
             pg_ctl=postgresql_ctl,
             host=pg_host,


### PR DESCRIPTION
In FreeBSD jailed environments the loopback interface can not be used to
connect to pgsql, because it points to the loopback interface of the host and
not the jail.

Thus, it seems to pgsql like the connection is comming from the ip address
assigned to the jail, and the connection is rejected

This commit ensures that pgsql can be connected to from any host, when
run on a FreeBSD systems. Thus this package can be used in FreeBSD
jailed environments

This commit/PR originated from #105 