### PR TITLE
use container based travis-ci infrastructure - closes #129

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cache/*
 *.py[cod]
 
 # C extensions

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,11 @@
 language:
 - python
+sudo: false
 python:
 - '2.7'
 - '3.3'
 - '3.4'
 - '3.5'
-before_install:
-- wget -O redis-2.4.14.tar.gz https://redis.googlecode.com/files/redis-2.4.14.tar.gz
-- tar xzf redis-2.4.14.tar.gz
-- cd redis-2.4.14
-- make
-- make test
-- sudo make install
-- cd utils
-- yes | sudo ./install_server.sh
-- cd ../../
-- /usr/local/bin/redis-server --version
-- /usr/bin/redis-server --version
 install:
 - python setup.py develop
 - pip install -e .[mongodb,redis,rabbitmq,mysql,postgresql,elasticsearch,tests]

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
             'pytest-xdist',
             'coveralls',
             'pylama',
+            'Mock',
         ],
         'mysql': ['mysqlclient'],
         'postgresql': ['psycopg2'],


### PR DESCRIPTION
- do not actually download redis < 2.6 for tests, but rather mock expected output in process fixture for test