### PR TITLE
hooks to process fixtures - closes #121

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 CHANGES
 =======
 
+0.13.0
+----------
+
+- [bugfix] added hooks to all process fixtures to check if process is running, and if not try to start it again
+
 0.12.0
 ----------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 CHANGES
 =======
 
-0.13.0
+Unreleased
 ----------
 
 - [bugfix] added hooks to all process fixtures to check if process is running, and if not try to start it again

--- a/src/pytest_dbfixtures/factories/elasticsearch.py
+++ b/src/pytest_dbfixtures/factories/elasticsearch.py
@@ -109,6 +109,11 @@ def elasticsearch_proc(host='127.0.0.1', port=9201, cluster_name=None,
             shutil.rmtree(home_path)
 
         request.addfinalizer(finalize_elasticsearch)
+
+        def pytest_runtest_setup(item):
+            if elasticsearch_executor.running() == False:
+                elasticsearch_executor.start()
+
         return elasticsearch_executor
 
     return elasticsearch_proc_fixture

--- a/src/pytest_dbfixtures/factories/elasticsearch.py
+++ b/src/pytest_dbfixtures/factories/elasticsearch.py
@@ -110,7 +110,7 @@ def elasticsearch_proc(host='127.0.0.1', port=9201, cluster_name=None,
 
         request.addfinalizer(finalize_elasticsearch)
 
-        def pytest_runtest_setup(item):
+        def pytest_runtest_setup():
             if elasticsearch_executor.running() == False:
                 elasticsearch_executor.start()
 

--- a/src/pytest_dbfixtures/factories/mongo.py
+++ b/src/pytest_dbfixtures/factories/mongo.py
@@ -93,7 +93,7 @@ def mongo_proc(executable=None, params=None, host=None, port=None,
 
         request.addfinalizer(mongo_executor.stop)
 
-        def pytest_runtest_setup(item):
+        def pytest_runtest_setup():
             if mongo_executor.running() == False:
                 mongo_executor.start()
 

--- a/src/pytest_dbfixtures/factories/mongo.py
+++ b/src/pytest_dbfixtures/factories/mongo.py
@@ -93,6 +93,10 @@ def mongo_proc(executable=None, params=None, host=None, port=None,
 
         request.addfinalizer(mongo_executor.stop)
 
+        def pytest_runtest_setup(item):
+            if mongo_executor.running() == False:
+                mongo_executor.start()
+
         return mongo_executor
 
     return mongo_proc_fixture

--- a/src/pytest_dbfixtures/factories/mysql.py
+++ b/src/pytest_dbfixtures/factories/mysql.py
@@ -146,6 +146,10 @@ def mysql_proc(executable=None, admin_executable=None, init_executable=None,
 
         request.addfinalizer(stop_server_and_remove_directory)
 
+        def pytest_runtest_setup(item):
+            if mysql_executor.running() == False:
+                mysql_executor.start()
+
         return mysql_executor
 
     return mysql_proc_fixture

--- a/src/pytest_dbfixtures/factories/mysql.py
+++ b/src/pytest_dbfixtures/factories/mysql.py
@@ -146,7 +146,7 @@ def mysql_proc(executable=None, admin_executable=None, init_executable=None,
 
         request.addfinalizer(stop_server_and_remove_directory)
 
-        def pytest_runtest_setup(item):
+        def pytest_runtest_setup():
             if mysql_executor.running() == False:
                 mysql_executor.start()
 

--- a/src/pytest_dbfixtures/factories/postgresql.py
+++ b/src/pytest_dbfixtures/factories/postgresql.py
@@ -203,7 +203,7 @@ def postgresql_proc(executable=None, host=None, port=None, logs_prefix=''):
         if '-w' in config.postgresql.startparams:
             wait_for_postgres(logfile_path, START_INFO)
 
-        def pytest_runtest_setup(item):
+        def pytest_runtest_setup():
             if postgresql_executor.running() == False:
                 postgresql_executor.start()
 

--- a/src/pytest_dbfixtures/factories/postgresql.py
+++ b/src/pytest_dbfixtures/factories/postgresql.py
@@ -203,6 +203,10 @@ def postgresql_proc(executable=None, host=None, port=None, logs_prefix=''):
         if '-w' in config.postgresql.startparams:
             wait_for_postgres(logfile_path, START_INFO)
 
+        def pytest_runtest_setup(item):
+            if postgresql_executor.running() == False:
+                postgresql_executor.start()
+
         return postgresql_executor
 
     return postgresql_proc_fixture

--- a/src/pytest_dbfixtures/factories/rabbitmq.py
+++ b/src/pytest_dbfixtures/factories/rabbitmq.py
@@ -217,6 +217,10 @@ def rabbitmq_proc(config_file=None, server=None, host=None, port=None,
 
         rabbit_executor.start()
 
+        def pytest_runtest_setup(item):
+            if rabbit_executor.running() == False:
+                rabbit_executor.start()
+
         return rabbit_executor
 
     return rabbitmq_proc_fixture

--- a/src/pytest_dbfixtures/factories/rabbitmq.py
+++ b/src/pytest_dbfixtures/factories/rabbitmq.py
@@ -217,7 +217,7 @@ def rabbitmq_proc(config_file=None, server=None, host=None, port=None,
 
         rabbit_executor.start()
 
-        def pytest_runtest_setup(item):
+        def pytest_runtest_setup():
             if rabbit_executor.running() == False:
                 rabbit_executor.start()
 

--- a/src/pytest_dbfixtures/factories/redis.py
+++ b/src/pytest_dbfixtures/factories/redis.py
@@ -109,6 +109,10 @@ def redis_proc(executable=None, params=None, config_file=None,
         redis_executor.start()
         request.addfinalizer(redis_executor.stop)
 
+        def pytest_runtest_setup(item):
+            if redis_executor.running() == False:
+                redis_executor.start()
+
         return redis_executor
 
     return redis_proc_fixture

--- a/src/pytest_dbfixtures/factories/redis.py
+++ b/src/pytest_dbfixtures/factories/redis.py
@@ -109,7 +109,7 @@ def redis_proc(executable=None, params=None, config_file=None,
         redis_executor.start()
         request.addfinalizer(redis_executor.stop)
 
-        def pytest_runtest_setup(item):
+        def pytest_runtest_setup():
             if redis_executor.running() == False:
                 redis_executor.start()
 

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -20,3 +20,10 @@ elasticsearch_random = factories.elasticsearch('elasticsearch_proc_random')
 def test_random_port(elasticsearch_random):
     """Tests if elasticsearch fixture can be started on random port"""
     assert elasticsearch_random.info()['status'] == 200
+
+
+elasticsearch_proc.stop()
+
+
+def test_restart_stopped_process(elasticsearch_proc):
+    assert elasticsearch_proc.running() is True

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -59,3 +59,10 @@ def test_random_port(mongodb_rand):
     server_info = mongodb_rand.server_info()
     assert 'ok' in server_info
     assert server_info['ok'] == 1.0
+
+
+mongo_proc.stop()
+
+
+def test_restart_stopped_process(mongo_proc):
+    assert mongo_proc.running() is True

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -40,3 +40,10 @@ def test_random_port(mysql_rand):
     """Tests if mysql fixture can be started on random port"""
     mysql = mysql_rand
     mysql.cursor()
+
+
+mysql_proc.stop()
+
+
+def test_restart_stopped_process(mysql_proc):
+    assert mysql_proc.running() is True

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -53,3 +53,10 @@ postgresql_rand = factories.postgresql('postgresql_rand_proc')
 def test_rand_postgres_port(postgresql_rand):
     """Tests if postgres fixture can be started on random port"""
     assert postgresql_rand.status == psycopg2.extensions.STATUS_READY
+
+
+postgresql_proc.stop()
+
+
+def test_restart_stopped_process(postgresql_proc):
+    assert postgresql_proc.running() is True

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -95,3 +95,10 @@ def test_random_port_node_names(rabbitmq_rand_proc2, rabbitmq_rand_proc3):
     """
     assert (rabbitmq_rand_proc2.env['RABBITMQ_NODENAME'] !=
             rabbitmq_rand_proc3.env['RABBITMQ_NODENAME'])
+
+
+rabbitmq_proc.stop()
+
+
+def test_restart_stopped_process(rabbitmq_proc):
+    assert rabbitmq_proc.running() is True

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -91,3 +91,10 @@ def test_compare_version(versions, result):
 ])
 def test_extract_version(text, result):
     assert extract_version(text) == result
+
+
+redis_proc.stop()
+
+
+def test_restart_stopped_process(redis_proc):
+    assert redis_proc.running() is True


### PR DESCRIPTION
Added hooks to all process fixtures to check if process is running, and
if not, try to start it again.