### PR TITLE
Make pg_ctl stop not wait for the server to stop, fixing a possible test hang

### DIFF
--- a/src/pytest_dbfixtures/executors/postgresql.py
+++ b/src/pytest_dbfixtures/executors/postgresql.py
@@ -103,7 +103,7 @@ class PostgreSQLExecutor(TCPExecutor):
     def stop(self):
         """Issues a stop request to pg_ctl"""
         subprocess.check_output(
-            '{pg_ctl} stop -D {datadir} -m f'.format(
+            '{pg_ctl} stop -D {datadir} -m f -W'.format(
                 pg_ctl=self.pg_ctl,
                 datadir=self.datadir,
                 port=self.port,


### PR DESCRIPTION
Waiting for server to stop seems unnecessary, and disabling it (via the `-W` option) seems to fix fixture teardown hang (killing the pytest worker process) when using xdist in a project using pytest-dbfixtures.