### PR TITLE
Elasticsearch 2.* issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,31 @@
 language:
 - python
-sudo: false
+sudo: required
 python:
 - '2.7'
 - '3.3'
 - '3.4'
 - '3.5'
 env:
-  - INSTALLATION="python setup.py develop" XDIST=1
+ - INSTALLATION="python setup.py develop" XDIST=1 ES_URL="https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.2/elasticsearch-2.3.2.deb"
+  - INSTALLATION="python setup.py develop" XDIST=1 ES_URL="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.4.deb"
   # unfortunatelly, xdist hangs if there's any error in the slave threads, and there, pytest fires all the hooks
-  - INSTALLATION="pip install ." XDIST=0
+  - INSTALLATION="pip install ." XDIST=0 ES_URL="https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.2/elasticsearch-2.3.2.deb"
+  - INSTALLATION="pip install ." XDIST=0 ES_URL="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.4.deb"
+before_install:
+    - curl -O $ES_URL
+    - ES_DEB=$(echo $ES_URL | rev | cut -d "/" -f 1 | rev)
+    - sudo dpkg -i --force-confnew $ES_DEB
+    - sudo service elasticsearch restart
+    - sudo usermod -G elasticsearch $USER
 install:
 - $INSTALLATION
 - pip install pytest_dbfixtures[mongodb,redis,rabbitmq,mysql,postgresql,elasticsearch,tests]
 - pip install wheel
+before_script:
+    - sleep 10
 script:
-- py.test -n $XDIST --max-slave-restart=0 --showlocals --verbose --cov pytest_dbfixtures tests -p no:dbfixtures
+- sudo -E su $USER -c ". $VIRTUAL_ENV/bin/activate; py.test -n $XDIST --max-slave-restart=0 --showlocals --verbose --cov pytest_dbfixtures tests -p no:dbfixtures"
 - pylama
 after_success:
 - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,23 +7,26 @@ python:
 - '3.4'
 - '3.5'
 env:
- - INSTALLATION="python setup.py develop" XDIST=1 ES_URL="https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.2/elasticsearch-2.3.2.deb"
+  - INSTALLATION="python setup.py develop" XDIST=1 ES_URL="https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.2/elasticsearch-2.3.2.deb"
   - INSTALLATION="python setup.py develop" XDIST=1 ES_URL="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.4.deb"
   # unfortunatelly, xdist hangs if there's any error in the slave threads, and there, pytest fires all the hooks
   - INSTALLATION="pip install ." XDIST=0 ES_URL="https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.3.2/elasticsearch-2.3.2.deb"
   - INSTALLATION="pip install ." XDIST=0 ES_URL="https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.4.deb"
 before_install:
-    - curl -O $ES_URL
-    - ES_DEB=$(echo $ES_URL | rev | cut -d "/" -f 1 | rev)
-    - sudo dpkg -i --force-confnew $ES_DEB
-    - sudo service elasticsearch restart
-    - sudo usermod -G elasticsearch $USER
+  - curl -O $ES_URL
+  - ES_DEB=$(echo $ES_URL | rev | cut -d "/" -f 1 | rev)
+  - sudo dpkg -i --force-confnew $ES_DEB
+  - sudo service elasticsearch restart
+  - sudo usermod -G elasticsearch $USER
+  - ES_PIP_VERSION="$(echo $ES_URL | cut -d "-" -f 2 | cut -d "." -f 1,2).0"
 install:
 - $INSTALLATION
+- pip install elasticsearch==$ES_PIP_VERSION
 - pip install pytest_dbfixtures[mongodb,redis,rabbitmq,mysql,postgresql,elasticsearch,tests]
 - pip install wheel
 before_script:
-    - sleep 10
+# ensure elasticsearch has enough time to start
+- sleep 10
 script:
 - sudo -E su $USER -c ". $VIRTUAL_ENV/bin/activate; py.test -n $XDIST --max-slave-restart=0 --showlocals --verbose --cov pytest_dbfixtures tests -p no:dbfixtures"
 - pylama

--- a/src/pytest_dbfixtures/factories/elasticsearch.py
+++ b/src/pytest_dbfixtures/factories/elasticsearch.py
@@ -75,7 +75,13 @@ def elasticsearch_proc(host='127.0.0.1', port=9201, cluster_name=None,
                 index_store_type
             )
         else:
-            index_store_type_option = ''
+            elasticsearch, _ = try_import('elasticsearch', request)
+            if elasticsearch.__version__[0] < 2:
+                index_store_type_option = '--index.store.type={}'.format(
+                    'memory'
+                )
+            else:
+                index_store_type_option = ''
 
         command_exec = '''
             {deamon} -p {pidfile} --http.port={port}

--- a/src/pytest_dbfixtures/factories/elasticsearch.py
+++ b/src/pytest_dbfixtures/factories/elasticsearch.py
@@ -71,7 +71,9 @@ def elasticsearch_proc(host='127.0.0.1', port=9201, cluster_name=None,
         cluster = cluster_name or 'dbfixtures.{0}'.format(elasticsearch_port)
         multicast_enabled = str(discovery_zen_ping_multicast_enabled).lower()
         if index_store_type is not None:
-            index_store_type_option = '--index.store.type={}'.format(index_store_type)
+            index_store_type_option = '--index.store.type={}'.format(
+                index_store_type
+            )
         else:
             index_store_type_option = ''
 

--- a/src/pytest_dbfixtures/factories/elasticsearch.py
+++ b/src/pytest_dbfixtures/factories/elasticsearch.py
@@ -28,7 +28,7 @@ from pytest_dbfixtures.port import get_port
 def elasticsearch_proc(host='127.0.0.1', port=9201, cluster_name=None,
                        network_publish_host='127.0.0.1',
                        discovery_zen_ping_multicast_enabled=False,
-                       index_store_type='memory', logs_prefix=''):
+                       index_store_type=None, logs_prefix=''):
     """
     Creates elasticsearch process fixture.
 
@@ -49,8 +49,7 @@ def elasticsearch_proc(host='127.0.0.1', port=9201, cluster_name=None,
     :param bool discovery_zen_ping_multicast_enabled: whether to enable or
         disable host discovery
         http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-discovery-zen.html
-    :param str index_store_type: index.store.type setting. *memory* by default
-        to speed up tests
+    :param str index_store_type: index.store.type setting.
     :param str logs_prefix: prefix for log filename
     """
     @pytest.fixture(scope='session')
@@ -71,6 +70,10 @@ def elasticsearch_proc(host='127.0.0.1', port=9201, cluster_name=None,
         work_path = '/tmp/elasticsearch_{0}_tmp'.format(elasticsearch_port)
         cluster = cluster_name or 'dbfixtures.{0}'.format(elasticsearch_port)
         multicast_enabled = str(discovery_zen_ping_multicast_enabled).lower()
+        if index_store_type is not None:
+            index_store_type_option = '--index.store.type={}'.format(index_store_type)
+        else:
+            index_store_type_option = ''
 
         command_exec = '''
             {deamon} -p {pidfile} --http.port={port}
@@ -80,7 +83,7 @@ def elasticsearch_proc(host='127.0.0.1', port=9201, cluster_name=None,
             --cluster.name={cluster}
             --network.publish_host='{network_publish_host}'
             --discovery.zen.ping.multicast.enabled={multicast_enabled}
-            --index.store.type={index_store_type}
+            {index_store_type_option}
             '''.format(
             deamon=config.elasticsearch.deamon,
             pidfile=pidfile,
@@ -91,8 +94,7 @@ def elasticsearch_proc(host='127.0.0.1', port=9201, cluster_name=None,
             cluster=cluster,
             network_publish_host=network_publish_host,
             multicast_enabled=multicast_enabled,
-            index_store_type=index_store_type
-
+            index_store_type_option=index_store_type_option
         )
 
         elasticsearch_executor = HTTPExecutor(

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -1,3 +1,6 @@
+
+import re
+import elasticsearch as es_module
 from pytest_dbfixtures import factories
 
 
@@ -25,3 +28,15 @@ def test_index_creation(elasticsearch):
     name = 'mytestindex'
     elasticsearch.indices.create(index=name)
     assert name in elasticsearch.indices.get_settings().keys()
+
+
+def test_index_type(elasticsearch_proc):
+    """Tests if index creation via elasticsearch fixture succeeds"""
+    cmd = elasticsearch_proc.command
+    index_store_type = re.findall(r'--index\.store\.type=(.*?)(?:--|\n)', cmd)
+    hosts = '{0}:{1}'.format(elasticsearch_proc.host, elasticsearch_proc.port)
+    client = es_module.Elasticsearch(hosts=hosts)
+    es_version = client.info()['version']['number']
+
+    if int(es_version[0]) < 2:
+        assert index_store_type[0].strip() == 'memory'

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -8,9 +8,7 @@ def test_elastic_process(elasticsearch_proc):
 
 def test_elasticsarch(elasticsearch):
     """Tests if elasticsearch fixtures connects to process."""
-
-    info = elasticsearch.info()
-    assert info['status'] == 200
+    assert elasticsearch.cluster.health()['status'] == 'green'
 
 
 elasticsearch_proc_random = factories.elasticsearch_proc(port='?')
@@ -19,4 +17,5 @@ elasticsearch_random = factories.elasticsearch('elasticsearch_proc_random')
 
 def test_random_port(elasticsearch_random):
     """Tests if elasticsearch fixture can be started on random port"""
-    assert elasticsearch_random.info()['status'] == 200
+    assert elasticsearch_random.cluster.health()['status'] == 'green'
+

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -21,7 +21,7 @@ def test_random_port(elasticsearch_random):
 
 
 def test_index_creation(elasticsearch):
+    """Tests if index creation via elasticsearch fixture succeeds"""
     name = 'mytestindex'
     elasticsearch.indices.create(index=name)
     assert name in elasticsearch.indices.get_settings().keys()
-

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -19,3 +19,9 @@ def test_random_port(elasticsearch_random):
     """Tests if elasticsearch fixture can be started on random port"""
     assert elasticsearch_random.cluster.health()['status'] == 'green'
 
+
+def test_index_creation(elasticsearch):
+    name = 'mytestindex'
+    elasticsearch.indices.create(index=name)
+    assert name in elasticsearch.indices.get_settings().keys()
+


### PR DESCRIPTION
Tries to resolve #148

Fixes failing tests by, instead of using `elasticsearch.info()`, checking the status of the cluster health API (`elasticsearch.cluster.health()`) 

Removed default index.store.type setting('memory') as [in-memroy indexes are no longer supported](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_20_setting_changes.html#_in_memory_indices)

The support for Elasticsearch 2.\* is far from being complete. This is just a fix of the issues I ran into.
