### PR TITLE
Provide a Vagrantfile for running tests locally; fixes #157

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,9 @@ docs/_build/
 # osx
 .DS_Store
 ._.DS_Store
+
+# editor backup files
+*~
+
+# Vagrant
+.vagrant/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -42,3 +42,24 @@ Coding style
 
 #. All python coding style are being enforced by `Pylama <https://pypi.python.org/pypi/pylama>`_ and configured in pylama.ini file.
 #. Additional, not always mandatory checks are being performed by `QuantifiedCode <https://www.quantifiedcode.com/app/project/gh:ClearcodeHQ:pytest-dbfixtures>`_
+
+
+Vagrant
+-------
+
+Since pytest-dbfixtures requires having several database servers installed locally for its tests to run, we provide a
+Vagrantfile for local development with `Vagrant <https://www.vagrantup.com/>`_.
+
+It is tested with Vagrant-LXC.
+
+To start the Vagrant instance, run ``vagrant up`` in the ``pytest-dbfixtures`` directory (it's slow, since dependencies
+are downloaded). Run ``vagrant ssh`` to log in on the Vagrant instance. The project source is mounted (or copied) in
+the ``/vagrant`` directory.
+
+Run tests in the virtualenv inside Vagrant::
+
+    . venv/bin/activate
+    cd /vagrant
+    py.test -x
+
+Run ``vagrant destroy`` to delete the Vagrant instance.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,16 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "debian/jessie64"
+
+  if Vagrant.has_plugin?('vagrant-cachier')
+    # Use the default vagrant-cachier autodetection, with one cache for all instances from the same box.
+    config.cache.scope = :box
+  end
+
+  # Run provisioning script as the vagrant user, not root. Otherwise we would easily accidentally e.g. create
+  # non-vagrant-writeable files in /home/vagrant, while not having root permissions for e.g. apt-get will error during
+  # provisioning.
+  config.vm.provision 'shell', path: 'bootstrap.sh', privileged: false
+end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+# Provision a fresh Vagrant instance to be able to develop pytest-dbfixtures or run its tests. This script runs as the
+# vagrant user.
+
+# Stop on error. Log invoked commands.
+set -ex
+
+# MongoDB needs several gigabytes of free space in /tmp, while vagrant-lxc mounts only 2G. See
+# <https://github.com/fgrehm/vagrant-lxc/issues/406> for details.
+sudo mount -o remount,size=5G /tmp
+
+# We need CA certificates to download keys over HTTPS.
+sudo apt-get update
+sudo apt-get install -y ca-certificates
+
+# Add keys and repos for third-party packages.
+wget -qO - https://packages.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
+wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+echo "deb http://packages.elastic.co/elasticsearch/1.7/debian stable main" \
+    | sudo tee -a /etc/apt/sources.list.d/elasticsearch-1.7.list
+echo "deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main" \
+    | sudo tee -a /etc/apt/sources.list.d/pgdg.list
+
+# Set MySQL root password so its installation won't block.
+sudo debconf-set-selections <<EOF
+mysql-server mysql-server/root_password password 123
+mysql-server mysql-server/root_password_again password 123
+EOF
+
+sudo apt-get update
+sudo apt-get install -y \
+     build-essential \
+     elasticsearch \
+     libmysqlclient-dev \
+     libpq-dev \
+     mongodb-server \
+     mysql-server \
+     openjdk-7-jre-headless \
+     postgresql-9.1 \
+     postgresql-9.2 \
+     postgresql-9.3 \
+     postgresql-9.4 \
+     python2.7-dev \
+     rabbitmq-server \
+     redis-server \
+     virtualenv
+
+# Install DynamoDB Local into the default path searched by pytest-dbfixtures.
+mkdir /tmp/dynamodb
+wget -qO - http://dynamodb-local.s3-website-us-west-2.amazonaws.com/dynamodb_local_latest \
+    | tar xz --directory /tmp/dynamodb
+
+# Stop PostgreSQL: they will use the port that postgresql_proc uses by default.
+sudo service postgresql stop
+sudo update-rc.d postgresql disable
+
+# Make a virtualenv, install Python dependencies.
+virtualenv /home/vagrant/venv
+. /home/vagrant/venv/bin/activate
+cd /vagrant
+python setup.py develop
+pip install pytest_dbfixtures[mongodb,redis,rabbitmq,mysql,postgresql,elasticsearch,dynamodb,tests]
+pip install -r requirements-test.txt
+
+# Delete compiled modules, otherwise imports will fail if these were compiled outside Vagrant, having different paths.
+find . -name '*.py[co]' -delete

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+# We must not use the dbfixtures plugin in its tests.
+addopts = -p no:dbfixtures


### PR DESCRIPTION
Tested with vagrant-lxc.

Missing things:
- testing with VirtualBox or libvirt
- using other Python versions than 2.7
- extra services might start on boot
- DynamoDB gets removed on reboot since it's installed to a temporary path by default
- DynamoDB download is not cached by vagrant-cachier
