### PR TITLE
- pin rabbitby in tests to 0.27.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 CHANGES
 =======
 
+unreleased
+------
+
+- [fix] support for rabbitpy 0.27.x
+
+
 0.14.3
 ------
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,7 +9,7 @@ pyaml==15.8.2
 pymlconf==0.3.21
 pymongo==3.2.2
 pytest==2.8.7
-rabbitpy==0.26.2
+rabbitpy==0.27.1
 redis==2.10.5
 pyflakes==1.2.3
 pep257==0.7.0

--- a/src/pytest_dbfixtures/factories/rabbitmq_client.py
+++ b/src/pytest_dbfixtures/factories/rabbitmq_client.py
@@ -101,7 +101,7 @@ def rabbitmq(process_fixture_name, teardown=clear_rabbitmq):
         rabbitpy, config = try_import('rabbitpy', request)
 
         connection = rabbitpy.Connection(
-            'amqp://{host}:{port}/%2F'.format(
+            'amqp://guest:guest@{host}:{port}/%2F'.format(
                 host=process.host,
                 port=process.port
             )


### PR DESCRIPTION
specifically state guest account and guest password for rabbitmq fixture