### PR TITLE
Use tempfile.gettempdir instead of hardcoded /tmp, refs #151

### DIFF
--- a/src/pytest_dbfixtures/conf/redis.conf
+++ b/src/pytest_dbfixtures/conf/redis.conf
@@ -13,5 +13,4 @@ databases 128
 #save 60 10000
 rdbcompression yes
 dbfilename dump.rdb
-dir /tmp/
 appendonly no

--- a/src/pytest_dbfixtures/factories/elasticsearch.py
+++ b/src/pytest_dbfixtures/factories/elasticsearch.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with pytest-dbfixtures.  If not, see <http://www.gnu.org/licenses/>.
 import shutil
+from tempfile import gettempdir
 
 import pytest
 from path import path
@@ -62,14 +63,15 @@ def elasticsearch_proc(host='127.0.0.1', port=9201, cluster_name=None,
         config = get_config(request)
         elasticsearch_port = get_port(port)
 
-        pidfile = '/tmp/elasticsearch.{0}.pid'.format(elasticsearch_port)
-        home_path = '/tmp/elasticsearch_{0}'.format(elasticsearch_port)
+        tmpdir = path(gettempdir())
+        pidfile = tmpdir / 'elasticsearch.{0}.pid'.format(elasticsearch_port)
+        home_path = tmpdir / 'elasticsearch_{0}'.format(elasticsearch_port)
         logsdir = path(request.config.getvalue('logsdir'))
         logs_path = logsdir / '{prefix}elasticsearch_{port}_logs'.format(
             prefix=logs_prefix,
             port=elasticsearch_port
         )
-        work_path = '/tmp/elasticsearch_{0}_tmp'.format(elasticsearch_port)
+        work_path = tmpdir / 'elasticsearch_{0}_tmp'.format(elasticsearch_port)
         cluster = cluster_name or 'dbfixtures.{0}'.format(elasticsearch_port)
         multicast_enabled = str(discovery_zen_ping_multicast_enabled).lower()
 

--- a/src/pytest_dbfixtures/factories/mysql.py
+++ b/src/pytest_dbfixtures/factories/mysql.py
@@ -19,6 +19,7 @@
 import os
 import shutil
 import subprocess
+from tempfile import gettempdir
 
 import pytest
 from path import path
@@ -103,9 +104,10 @@ def mysql_proc(executable=None, admin_executable=None, init_executable=None,
         mysql_host = host or config.mysql.host
         mysql_params = params or config.mysql.params
 
-        datadir = '/tmp/mysqldata_{port}'.format(port=mysql_port)
-        pidfile = '/tmp/mysql-server.{port}.pid'.format(port=mysql_port)
-        unixsocket = '/tmp/mysql.{port}.sock'.format(port=mysql_port)
+        tmpdir = path(gettempdir())
+        datadir = tmpdir / 'mysqldata_{port}'.format(port=mysql_port)
+        pidfile = tmpdir / 'mysql-server.{port}.pid'.format(port=mysql_port)
+        unixsocket = tmpdir / 'mysql.{port}.sock'.format(port=mysql_port)
         logsdir = path(request.config.getvalue('logsdir'))
         logfile_path = logsdir / '{prefix}mysql-server.{port}.log'.format(
             prefix=logs_prefix,
@@ -132,6 +134,7 @@ def mysql_proc(executable=None, admin_executable=None, init_executable=None,
             host=mysql_host,
             port=mysql_port,
         )
+        mysql_executor.socket_path = unixsocket
         mysql_executor.start()
 
         def stop_server_and_remove_directory():

--- a/src/pytest_dbfixtures/factories/mysql_client.py
+++ b/src/pytest_dbfixtures/factories/mysql_client.py
@@ -61,13 +61,12 @@ def mysql(process_fixture_name, user=None, passwd=None, db=None,
         proc_fixture = get_process_fixture(request, process_fixture_name)
 
         config = get_config(request)
-        mysql_port = proc_fixture.port
         mysql_host = proc_fixture.host
         mysql_user = user or config.mysql.user
         mysql_passwd = passwd or config.mysql.password
         mysql_db = db or config.mysql.db
 
-        unixsocket = '/tmp/mysql.{port}.sock'.format(port=mysql_port)
+        unixsocket = proc_fixture.socket_path
 
         MySQLdb, config = try_import(
             'MySQLdb', request, pypi_package='mysqlclient'

--- a/src/pytest_dbfixtures/factories/postgresql.py
+++ b/src/pytest_dbfixtures/factories/postgresql.py
@@ -20,6 +20,7 @@ import os
 import platform
 import shutil
 import subprocess
+from tempfile import gettempdir
 import time
 
 import pytest
@@ -168,7 +169,7 @@ def postgresql_proc(executable=None, host=None, port=-1, logs_prefix=''):
 
         pg_host = host or config.postgresql.host
         pg_port = get_port(port) or get_port(config.postgresql.port)
-        datadir = '/tmp/postgresqldata.{0}'.format(pg_port)
+        datadir = path(gettempdir()) / 'postgresqldata.{0}'.format(pg_port)
         logsdir = path(request.config.getvalue('logsdir'))
         logfile_path = logsdir / '{prefix}postgresql.{port}.log'.format(
             prefix=logs_prefix,
@@ -180,7 +181,7 @@ def postgresql_proc(executable=None, host=None, port=-1, logs_prefix=''):
         )
 
         if 'FreeBSD' == platform.system():
-            with open(os.path.join(datadir, 'pg_hba.conf'), 'a') as f:
+            with (datadir / 'pg_hba.conf').open(mode='a') as f:
                 f.write('host all all 0.0.0.0/0 trust\n')
 
         postgresql_executor = PostgreSQLExecutor(

--- a/src/pytest_dbfixtures/factories/rabbitmq.py
+++ b/src/pytest_dbfixtures/factories/rabbitmq.py
@@ -19,6 +19,7 @@
 
 import os
 import subprocess
+from tempfile import gettempdir
 
 import pytest
 from path import path
@@ -185,7 +186,7 @@ def rabbitmq_proc(config_file=None, server=None, host=None, port=-1,
         rabbit_host = host or config.rabbit.host
         rabbit_port = get_port(port) or get_port(config.rabbit.port)
 
-        rabbit_path = path('/tmp/rabbitmq.{0}/'.format(rabbit_port))
+        rabbit_path = path(gettempdir()) / 'rabbitmq.{0}/'.format(rabbit_port)
 
         logsdir = path(request.config.getvalue('logsdir'))
         rabbit_log = logsdir / '{prefix}rabbit-server.{port}.log'.format(

--- a/src/pytest_dbfixtures/factories/redis.py
+++ b/src/pytest_dbfixtures/factories/redis.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with pytest-dbfixtures.  If not, see <http://www.gnu.org/licenses/>.
 import os
+from tempfile import gettempdir
 
 import pytest
 from path import path
@@ -83,7 +84,7 @@ def redis_proc(executable=None, params=None, config_file=None,
             '''{redis_exec} {config}
             --pidfile {pidfile} --unixsocket {unixsocket}
             --dbfilename {dbfilename} --logfile {logfile_path}
-            --port {port} {params}'''
+            --port {port} --dir {tmpdir} {params}'''
             .format(
                 redis_exec=redis_exec,
                 params=redis_params,
@@ -92,7 +93,8 @@ def redis_proc(executable=None, params=None, config_file=None,
                 unixsocket=unixsocket,
                 dbfilename=dbfilename,
                 logfile_path=logfile_path,
-                port=redis_port
+                port=redis_port,
+                tmpdir=gettempdir(),
             ),
             host=redis_host,
             port=redis_port,


### PR DESCRIPTION
Remaining uses of /tmp: default logs directory, default PostgreSQL Unix socket directory and DynamoDB installation path.