### PR TITLE
Makes postgresql fixture usable in multi-test test modules

### DIFF
--- a/src/pytest_dbfixtures/factories/postgresql.py
+++ b/src/pytest_dbfixtures/factories/postgresql.py
@@ -210,17 +210,18 @@ def postgresql_proc(executable=None, host=None, port=-1, logs_prefix=''):
     return postgresql_proc_fixture
 
 
-def postgresql(process_fixture_name, db=None):
+def postgresql(process_fixture_name, db=None, scope='function'):
     """
     postgresql database factory.
 
     :param str process_fixture_name: name of the process fixture
     :param int db: database name
+    :param str scope: scope of database fixture
     :rtype: func
     :returns: function which makes a connection to postgresql
     """
 
-    @pytest.fixture
+    @pytest.fixture(scope=scope)
     def postgresql_factory(request):
         """
         #. Load required process fixture.

--- a/src/pytest_dbfixtures/factories/postgresql.py
+++ b/src/pytest_dbfixtures/factories/postgresql.py
@@ -121,7 +121,7 @@ def drop_postgresql_database(psycopg2, user, host, port, db):
     conn = psycopg2.connect(user=user, host=host, port=port)
     conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
     cur = conn.cursor()
-    cur.execute('DROP DATABASE IF EXISTS %s' % db)
+    cur.execute('DROP DATABASE IF EXISTS %s;' % db)
     cur.close()
     conn.close()
 

--- a/src/pytest_dbfixtures/factories/postgresql.py
+++ b/src/pytest_dbfixtures/factories/postgresql.py
@@ -215,7 +215,7 @@ def postgresql(process_fixture_name, db=None, scope='function'):
     postgresql database factory.
 
     :param str process_fixture_name: name of the process fixture
-    :param int db: database name
+    :param str db: database name
     :param str scope: scope of database fixture
     :rtype: func
     :returns: function which makes a connection to postgresql


### PR DESCRIPTION
This PR fixes the following issues:

- The drop database statement had no effect due to a missing semicolon
- The factory-returned postgres fixture had its scope set to module (by default I presume) which does not work when you have a test module with multiple tests that each need a clean database
