### PR TITLE
Fix/postgres fixture

### DIFF
--- a/src/pytest_dbfixtures/factories/postgresql.py
+++ b/src/pytest_dbfixtures/factories/postgresql.py
@@ -121,7 +121,7 @@ def drop_postgresql_database(psycopg2, user, host, port, db):
     conn = psycopg2.connect(user=user, host=host, port=port)
     conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
     cur = conn.cursor()
-    cur.execute('DROP DATABASE IF EXISTS %s' % db)
+    cur.execute('DROP DATABASE IF EXISTS %s;' % db)
     cur.close()
     conn.close()
 

--- a/src/pytest_dbfixtures/factories/postgresql.py
+++ b/src/pytest_dbfixtures/factories/postgresql.py
@@ -215,7 +215,7 @@ def postgresql(process_fixture_name, db=None):
     postgresql database factory.
 
     :param str process_fixture_name: name of the process fixture
-    :param int db: database name
+    :param str db: database name
     :rtype: func
     :returns: function which makes a connection to postgresql
     """


### PR DESCRIPTION
This PR fixes the following issues:

- The drop database statement had no effect due to a missing semicolon