### PR TITLE
Fix tmpdir for mysql

### DIFF
--- a/src/pytest_dbfixtures/factories/mysql.py
+++ b/src/pytest_dbfixtures/factories/mysql.py
@@ -40,7 +40,7 @@ def remove_mysql_directory(datadir):
         shutil.rmtree(datadir)
 
 
-def init_mysql_directory(mysql_init, datadir):
+def init_mysql_directory(mysql_init, datadir, tmpdir):
     """
     #. Remove mysql directory if exist.
     #. `Initialize MySQL data directory
@@ -55,6 +55,7 @@ def init_mysql_directory(mysql_init, datadir):
         mysql_init,
         '--user=%s' % os.getenv('USER'),
         '--datadir=%s' % datadir,
+        '--tmpdir=%s' % tmpdir,
     )
     subprocess.check_output(' '.join(init_directory), shell=True)
 
@@ -114,13 +115,13 @@ def mysql_proc(executable=None, admin_executable=None, init_executable=None,
             port=mysql_port
         )
 
-        init_mysql_directory(mysql_init, datadir)
+        init_mysql_directory(mysql_init, datadir, tmpdir)
 
         mysql_executor = TCPExecutor(
             '''
             {mysql_server} --datadir={datadir} --pid-file={pidfile}
             --port={port} --socket={socket} --log-error={logfile_path}
-            --skip-syslog {params}
+            --tmpdir={tmpdir} --skip-syslog {params}
             '''
             .format(
                 mysql_server=mysql_exec,
@@ -130,6 +131,7 @@ def mysql_proc(executable=None, admin_executable=None, init_executable=None,
                 socket=unixsocket,
                 logfile_path=logfile_path,
                 params=mysql_params,
+                tmpdir=tmpdir,
             ),
             host=mysql_host,
             port=mysql_port,

--- a/src/pytest_dbfixtures/factories/mysql.py
+++ b/src/pytest_dbfixtures/factories/mysql.py
@@ -19,7 +19,7 @@
 import os
 import shutil
 import subprocess
-from tempfile import gettempdir
+from tempfile import mkdtemp
 
 import pytest
 from path import path
@@ -104,7 +104,7 @@ def mysql_proc(executable=None, admin_executable=None, init_executable=None,
         mysql_host = host or config.mysql.host
         mysql_params = params or config.mysql.params
 
-        tmpdir = path(gettempdir())
+        tmpdir = path(mkdtemp(prefix="pytest-mysql-"))
         datadir = tmpdir / 'mysqldata_{port}'.format(port=mysql_port)
         pidfile = tmpdir / 'mysql-server.{port}.pid'.format(port=mysql_port)
         unixsocket = tmpdir / 'mysql.{port}.sock'.format(port=mysql_port)
@@ -146,7 +146,7 @@ def mysql_proc(executable=None, admin_executable=None, init_executable=None,
             )
             subprocess.check_output(' '.join(shutdown_server), shell=True)
             mysql_executor.stop()
-            remove_mysql_directory(datadir)
+            remove_mysql_directory(tmpdir)
 
         request.addfinalizer(stop_server_and_remove_directory)
 

--- a/src/pytest_dbfixtures/factories/mysql.py
+++ b/src/pytest_dbfixtures/factories/mysql.py
@@ -48,6 +48,7 @@ def init_mysql_directory(mysql_init, datadir, tmpdir):
 
     :param str mysql_init: mysql_init executable
     :param str datadir: path to datadir
+    :param str tmpdir: path to tmpdir
 
     """
     remove_mysql_directory(datadir)


### PR DESCRIPTION
The `--tmpdir` option is necessary, otherwise there might be conflict with an existing daemon running as different user.