### PR TITLE
Fix errors when creating table from other process

### DIFF
--- a/src/pytest_dbfixtures/factories/mysql_client.py
+++ b/src/pytest_dbfixtures/factories/mysql_client.py
@@ -80,7 +80,7 @@ def mysql(process_fixture_name, user=None, passwd=None, db=None,
         )
 
         mysql_conn.query(
-            '''CREATE DATABASE {name}
+            '''CREATE DATABASE IF NOT EXISTS {name}
             DEFAULT CHARACTER SET {charset}
             DEFAULT COLLATE {collation}'''
             .format(


### PR DESCRIPTION
This little change should fix errors that occur when using the fixture on multiple processes
